### PR TITLE
CI workflow update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,5 +37,3 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
-        with:
-          file: lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,47 +2,40 @@ name: CI
 on:
   pull_request:
     branches:
-      - main
+      - '**'
   push:
     branches:
-      - main
-    tags: '*'
+      - '**'
+    tags: ["*"]
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
+      actions: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
-        version:
-          - '1' 
-          - '1.7.2' 
-          - 'nightly' 
-        os:
-          - ubuntu-latest
-          - macOS-latest
-          - windows-latest
-        arch:
-          - x64
+        downgrade_mode: ["deps"]
+        version: ["lts", "1", "pre", "nightly"]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        arch: ["default"]
+        show-versioninfo: [false]
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
+      - uses: julia-actions/julia-downgrade-compat@v2
         with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+          mode: ${{ matrix.downgrade_mode }}
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v5
         with:
           file: lcov.info


### PR DESCRIPTION
- Update ci.yml to use actions/checkout@v4 as v2 is deprecated
- Test lts, stable, pre and nightly on latest macOS, ubuntu, windows
- Bring in julia-actions/cache in place of actions/cache
- Implement downgrade compat check
- Update codecov/codecov-action to v5